### PR TITLE
Fixed Badge.vue component bug

### DIFF
--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -19,16 +19,19 @@ const props = withDefaults(
 
 const { mood, outline, size } = toRefs(props);
 
-const classes = computed(() => ({
+const badgeElementClasses = computed(() => ({
   [`mood-background-${mood.value}`]: !outline.value,
   [`mood-border-${mood.value}`]: true,
+}));
+
+const infoElementClasses = computed(() => ({
   [`size-${size.value}`]: true,
 }));
 </script>
 
 <template lang="pug">
-.badge(:class='classes')
-  Info(:mood="outline ? mood : 'white'")
+.badge(:class='badgeElementClasses')
+  Info(:mood="outline ? mood : 'white'" :class="infoElementClasses")
     slot(default)
 </template>
 


### PR DESCRIPTION
Fixed Badge.vue component bug - unable to adjust the size by prop. Moved size class to the Info element.