### PR TITLE
Fixed default-spacing rules broken by vue compiler scoped-CSS rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All important changes in vue-frontend-widgets
 
+## [2.0.3] - 2026-07-06
+- Fixed default spacing being broken in all 2.0.x builds. Vue compiler >= 3.4.22 ([vuejs/core#10551](https://github.com/vuejs/core/pull/10551)) mangles scoped `* + X` selectors: it drops the leading `*` (browsers then discard the invalid rule — all inter-component margins disappeared) and mis-hosts `[data-v]` on `.align`/`.grid` in the row/grid overrides (elements following a Button/KpiCard/etc. in an `Align` row or `Grid` gained a phantom top margin). Selector heads in `default-spacing` now use `:where(*)`, and the two generic sibling families are written out explicitly so the scope attribute lands on the previous-sibling side, restoring pre-2.0.0 behavior.
+
 ## [2.0.0] - 2026-06-08
 - **BREAKING**: minimum Node version raised to **20**. CI workflows bumped from Node 18.9 to Node 20. Strictest dep floor is `vitest@^4` (no Node 18.x support); vite 6 and @vue/eslint-config-typescript 13 also require Node 18.18+/20+.
 - Dependency upgrades clearing critical, high, and moderate security advisories:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elsilent/vue-frontend-widgets",
   "type": "module",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "files": [
     "dist"
   ],

--- a/src/styles/spacing.scss
+++ b/src/styles/spacing.scss
@@ -71,22 +71,52 @@ $side-menu-width-collapsed: 60px;
 }
 
 @mixin default-spacing {
-  @include reasonable-spacing('*', ':not(.no-spacing):not(.spacing-small)', $padding-size-normal);
-  @include reasonable-spacing('*', ':not(.no-spacing).spacing-small', $padding-size-small);
+  // ':where(*)' instead of bare '*': vue compiler >= 3.4.22 drops a leading '*'
+  // before a combinator in scoped styles, emitting invalid CSS that browsers ignore.
+  // Same matching, same (zero) specificity. See https://github.com/vuejs/core/pull/10551
+
+  // Written out by hand (not via reasonable-spacing): with a ':not(...)' target the
+  // compiler would host [data-v] on '.align' / '.grid', so the rules would never match.
+  :where(*) + *:not(.no-spacing):not(.spacing-small) {
+    margin-top: $padding-size-normal;
+  }
+  :where(*):where(.align:not(.column) > *) + *:not(.no-spacing):not(.spacing-small) {
+    margin-top: 0;
+    margin-left: $padding-size-normal;
+  }
+  :where(*):where(.grid > *) + *:not(.no-spacing):not(.spacing-small) {
+    margin-top: 0;
+  }
+
+  :where(*) + *:not(.no-spacing).spacing-small {
+    margin-top: $padding-size-small;
+  }
+  :where(*):where(.align:not(.column) > *) + *:not(.no-spacing).spacing-small {
+    margin-top: 0;
+    margin-left: $padding-size-small;
+  }
+  :where(*):where(.grid > *) + *:not(.no-spacing).spacing-small {
+    margin-top: 0;
+  }
+
   @include reasonable-spacing(
-    '*',
+    ':where(*)',
     '.align:not(.no-spacing):not(.spacing-small)',
     $padding-size-large-2
   );
-  @include reasonable-spacing('*', '.align:not(.no-spacing).spacing-small', $padding-size-large);
   @include reasonable-spacing(
-    '*',
+    ':where(*)',
+    '.align:not(.no-spacing).spacing-small',
+    $padding-size-large
+  );
+  @include reasonable-spacing(
+    ':where(*)',
     '.grid:not(.no-spacing):not(.spacing-small)',
     $padding-size-large-2
   );
-  @include reasonable-spacing('*', '.card:not(.no-spacing)', $padding-size-large-2);
-  @include reasonable-spacing('*', '.header:not(.no-spacing)', $padding-size-large-3);
-  @include reasonable-spacing('*', '.info-text:not(.no-spacing)', $padding-size-large);
+  @include reasonable-spacing(':where(*)', '.card:not(.no-spacing)', $padding-size-large-2);
+  @include reasonable-spacing(':where(*)', '.header:not(.no-spacing)', $padding-size-large-3);
+  @include reasonable-spacing(':where(*)', '.info-text:not(.no-spacing)', $padding-size-large);
   @include reasonable-spacing('.dot', '.info-text:not(.no-spacing)', $padding-size-small-3);
   @include reasonable-spacing('.icon', '.info-text:not(.no-spacing)', $padding-size-small-3);
   @include reasonable-spacing(
@@ -99,8 +129,12 @@ $side-menu-width-collapsed: 60px;
     '.align:not(.no-spacing)',
     $padding-size-small-2
   );
-  @include reasonable-spacing('*', '.kpi-distrubution-table:not(.no-spacing)', $padding-size-large);
-  @include reasonable-spacing('*', '.no-spacing', 0);
+  @include reasonable-spacing(
+    ':where(*)',
+    '.kpi-distrubution-table:not(.no-spacing)',
+    $padding-size-large
+  );
+  @include reasonable-spacing(':where(*)', '.no-spacing', 0);
   @include reasonable-spacing('.grid > *', '.no-spacing', 0);
 
   .flex-max {


### PR DESCRIPTION
Vue compiler >= 3.4.22 (vuejs/core#10551) drops a leading '*' before a combinator in scoped styles (emitting invalid CSS that browsers discard) and mis-hosts [data-v] on '.align'/'.grid' when the target is ':not(...)'. Selector heads now use ':where(*)' and the two generic sibling families are written out explicitly so the scope attribute lands correctly.