### PR TITLE
Fix the checked-state checkmark alignment in VirtualizedTreeSelect

### DIFF
--- a/src/components/VirtualizedTreeSelect.vue
+++ b/src/components/VirtualizedTreeSelect.vue
@@ -342,5 +342,11 @@ ElPopover(
     height: 4px;
     top: 8px;
   }
+  // element-plus 2.10+ added translate(-45%, -60%) to the checked-state transform,
+  // which conflicts with the absolute left/top positioning used just above.
+  // Cancel the translate so the checkmark sits where left/top says it should.
+  .el-checkbox__input.is-checked .el-checkbox__inner::after {
+    transform: rotate(45deg) scaleY(1);
+  }
 }
 </style>


### PR DESCRIPTION
The component positions the checkmark with absolute left/top, and the element-plus 2.10 upgrade added a translate to the checked-state transform that shifts it out of its box. TreeSelect was corrected for this at the time and this one was missed, so it gets the same rule.